### PR TITLE
Run mina in the contaienr environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,16 @@ In the client:
 
 ```ssh root@server```
 
-the development tree can be found on the client container, /obs-deployment-tool
+The development tree can be found on the client container
+`/obs-deployment-tool`, so it's possible to do:
+
+
+```cd /obs-deployment-tool```
+
+```bundle install```
+
+```mina -T```
+
 
 ### How to contribute with code
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,10 +2,9 @@
 
 require 'shellwords'
 require 'bundler/setup'
-# require 'mina/rails'
 require 'mina/deploy'
 
-require 'obs_deploy'
+require_relative '../lib/obs_deploy'
 
 class PendingMigrationError < StandardError; end
 

--- a/docker-files/client/Dockerfile
+++ b/docker-files/client/Dockerfile
@@ -1,8 +1,10 @@
 FROM opensuse/tumbleweed
 
 RUN zypper --gpg-auto-import-keys refresh
-RUN zypper install -y openssh vim iputils
+RUN zypper install -y openssh vim iputils gcc make ruby-devel libxml2-devel libxslt-devel
 
+RUN mkdir -p /root/.bundle
+COPY bundler-config /root/.bundle/config
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker-files/client/bundler-config
+++ b/docker-files/client/bundler-config
@@ -1,0 +1,1 @@
+BUNDLE_BUILD__NOKOGIRI: "--use-system-libraries"

--- a/docker-files/server/Dockerfile
+++ b/docker-files/server/Dockerfile
@@ -4,7 +4,7 @@ RUN zypper --gpg-auto-import-keys refresh
 RUN zypper install -y openssh vim iputils openssh-common
 
 RUN /usr/bin/ssh-keygen -A
-
+RUN mkdir -p /srv/www/obs/api/
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/lib/obs_deploy.rb
+++ b/lib/obs_deploy.rb
@@ -5,11 +5,11 @@ require 'net/http'
 require 'logger'
 
 require 'nokogiri'
-require 'obs_deploy/version'
-require 'obs_deploy/check_diff'
-require 'obs_deploy/zypper'
-require 'obs_deploy/systemctl'
-require 'obs_deploy/apache_sysconfig'
+require_relative 'obs_deploy/version'
+require_relative 'obs_deploy/check_diff'
+require_relative 'obs_deploy/zypper'
+require_relative 'obs_deploy/systemctl'
+require_relative 'obs_deploy/apache_sysconfig'
 require 'tempfile'
 
 module ObsDeploy


### PR DESCRIPTION
- Adapt Mina to move away from `obs_deploy`
- Adapt Path on `libs/obs_deploy`
- Add Docker provision on client to be able to run mina -T
- Improve README to reflect new changes