### PR TITLE
Add option to prevent SSL certificate verification 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
+.bundle
+.env
+.rspec_status
+bin
 docker-files/ssh-keys/id_rsa
 docker-files/ssh-keys/id_rsa.pub
 docker-files/ssh-keys/authorized_keys
-.rspec_status
 tmp
+vendor
+**/*.swp

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -14,10 +14,11 @@ set :domain, ENV['DOMAIN'] || 'obs'
 set :port, ENV['SSH_PORT'] || nil
 set :package_name, ENV['PACKAGE_NAME'] || 'obs-api'
 set :product, ENV['PRODUCT'] || 'SLE_12_SP4'
+set :https_verify_none, ENV['HTTPS_VERIFY_NONE'] == 'true'
 set :deploy_to, ENV['DEPLOY_TO_DIR'] || '/srv/www/obs/api/'
 
 set :user, ENV['obs_user'] || 'root'
-set :check_diff, ObsDeploy::CheckDiff.new(product: fetch(:product))
+set :check_diff, ObsDeploy::CheckDiff.new(product: fetch(:product), https_verify_none: fetch(:https_verify_none))
 
 # Let mina controls the dry-run
 set :zypper, ObsDeploy::Zypper.new(package_name: fetch(:package_name), dry_run: false)

--- a/lib/obs_deploy/check_diff.rb
+++ b/lib/obs_deploy/check_diff.rb
@@ -2,13 +2,24 @@
 
 module ObsDeploy
   class CheckDiff
-    def initialize(server: 'https://api.opensuse.org', product: 'SLE_12_SP4')
+    def initialize(server: 'https://api.opensuse.org', product: 'SLE_12_SP4', https_verify_none: false)
       @server = server
       @product = product
+      @https_verify_none = https_verify_none
+    end
+
+    def url_get(url)
+      return Net::HTTP.get(URI(url)) unless @https_verify_none
+
+      uri = URI.parse(url)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      http.get(uri).body
     end
 
     def package_version
-      doc = Nokogiri::XML(Net::HTTP.get(package_url))
+      doc = Nokogiri::XML(url_get(package_url))
       doc.xpath("//binary[starts-with(@filename, 'obs-api')]/@filename").to_s
     end
 
@@ -17,7 +28,7 @@ module ObsDeploy
     end
 
     def obs_running_commit
-      doc = Nokogiri::XML(Net::HTTP.get(about_url))
+      doc = Nokogiri::XML(url_get(about_url))
       doc.xpath('//commit/text()').to_s
     end
 
@@ -52,11 +63,11 @@ module ObsDeploy
     end
 
     def package_url
-      URI("#{@server}/public/build/OBS:Server:Unstable/#{@product}/x86_64/obs-server")
+      "https://build.opensuse.org/public/build/OBS:Server:Unstable/#{@product}/x86_64/obs-server"
     end
 
     def about_url
-      URI("#{@server}/about")
+      "#{@server}/about"
     end
   end
 end


### PR DESCRIPTION
This is meant to be used in some development environments, like, for example, an out-of-the-box OBS appliance.