### PR TITLE
RuboCop: exclude vendor subdirectory

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,4 @@ AllCops:
   MaxFilesInCache: 4000
   Exclude:
     - 'tmp/**/*'
+    - 'vendor/**/*'


### PR DESCRIPTION
We don't need to RuboCop check subdirectories where the binaries and the sources of the gems are installed.